### PR TITLE
Run hook in series by default.

### DIFF
--- a/tests/plugins/bar/time
+++ b/tests/plugins/bar/time
@@ -1,0 +1,4 @@
+#!/bin/bash
+date +%s
+sleep 2
+

--- a/tests/plugins/foo/time
+++ b/tests/plugins/foo/time
@@ -1,0 +1,4 @@
+#!/bin/bash
+date +%s
+cat
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,3 +9,14 @@
   result=$($BIN pre-build | wc -l)
   [[ $result -eq 2 ]]
 }
+
+@test "run tests in series" {
+  times=( $($BIN time) )
+  [[ $(( ${times[0]} - ${times[1]} )) -ge 2 ]]
+}
+
+@test "run tests in parallel" {
+  times=( $($BIN -p time) )
+  [[ $(( ${times[0]} - ${times[1]} )) -le 1 ]]
+}
+


### PR DESCRIPTION
Running hooks in parallel can cause conflicts, with eg apt-get
Serial mode is the default, it can be switched back to parallel with a command line switch.

Fixes #1 and progrium/dokku#366
