### PR TITLE
Add a trace mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.1.0
+VERSION = 0.1.1
 
 build: pluginhook
 

--- a/pluginhook.go
+++ b/pluginhook.go
@@ -14,7 +14,12 @@ import (
 
 func main() {
 	var parallel = flag.Bool("p", false, "Run hooks in parallel")
+	var trace = flag.Bool("x", false, "Trace mode")
 	flag.Parse()
+
+	if len(os.Getenv("PLUGINHOOK_TRACE")) > 0 {
+		*trace = true
+	}
 
 	pluginPath := os.Getenv("PLUGIN_PATH")
 	if pluginPath == "" {
@@ -60,6 +65,9 @@ func main() {
 
 		for i := 0; i < len(cmds); i++ {
 			go func(cmd exec.Cmd) {
+				if *trace {
+					fmt.Fprintln(os.Stderr, "Executing : ", cmd.Args)
+				}
 				err := cmd.Run()
 				if msg, ok := err.(*exec.ExitError); ok { // there is error code 
 					os.Exit(msg.Sys().(syscall.WaitStatus).ExitStatus())
@@ -72,6 +80,9 @@ func main() {
 		}
 	} else {
 		for i := 0; i < len(cmds); i++ {
+			if *trace {
+				fmt.Fprintln(os.Stderr, "Executing : ", cmds[i].Args)
+			}
 			err := cmds[i].Run()
 			if msg, ok := err.(*exec.ExitError); ok { // there is error code 
 				os.Exit(msg.Sys().(syscall.WaitStatus).ExitStatus())

--- a/tests/plugins/bar/cat
+++ b/tests/plugins/bar/cat
@@ -1,0 +1,3 @@
+#!/bin/bash
+cat
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,3 +20,14 @@
   [[ $(( ${times[0]} - ${times[1]} )) -le 1 ]]
 }
 
+@test "print trace of hook calls" {
+  stderr=$(echo Hello | $BIN -x cat 2>&1 >/dev/null)
+  [[ $stderr == Executing* ]]
+  stderr=$(echo Hello | $BIN -x -p cat 2>&1 >/dev/null)
+  [[ $stderr == Executing* ]]
+  stderr=$(echo Hello | PLUGINHOOK_TRACE=1 $BIN cat 2>&1 >/dev/null)
+  [[ $stderr == Executing* ]]
+  stderr=$(echo Hello | PLUGINHOOK_TRACE=1 $BIN -p cat 2>&1 >/dev/null)
+  [[ $stderr == Executing* ]]
+}
+


### PR DESCRIPTION
If the -x option is used, or the PLUGINHOOK_TRACE env var is non empty, pluginhook will log calls to hooks on stderr.

Example output : 

```
$ echo Hello | PLUGIN_PATH=./tests/plugins ./pluginhook -x pre-build ABC DEF
Executing :  [tests/plugins/bar/pre-build ABC DEF]
Executing :  [tests/plugins/foo/pre-build ABC DEF]
Hello
bar pre-build DEF
foo pre-build ABC DEF
```
