### PR TITLE
export `PLUGINHOOK_COMMAND_COUNT`

### DIFF
--- a/pluginhook.go
+++ b/pluginhook.go
@@ -61,6 +61,8 @@ func main() {
 		}
 	}
 
+        os.Setenv("PLUGINHOOK_COMMAND_COUNT", fmt.Sprintf("%d", len(cmds)))
+
 	if *parallel {
 		done := make(chan bool, len(cmds))
 


### PR DESCRIPTION
I have no experience in Go, but this patch seems simple enough not to break anything ;)

This way we could have a default behaviour if no plugin handles the event, ref: https://github.com/progrium/dokku/pull/1149

``` bash
pluginhook some-obscure-event $params
if [[ "$PLUGINHOOK_COMMAND_COUNT" -eq 0 ]]; then
  echo "No plugin handles the obscire-event, bailing out" >&2
  exit 1
fi 
```
